### PR TITLE
macOS docker for desktop ssh-agent support for link creation helper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,4 +15,5 @@ gateway: docker
 link:
 	docker run -e SSH_AGENT_PID=$$SSH_AGENT_PID -e SSH_AUTH_SOCK=$$SSH_AUTH_SOCK -v $$SSH_AUTH_SOCK:$$SSH_AUTH_SOCK --rm -it fractalnetworks/gateway-cli:latest $(GATEWAY) $(FQDN) $(EXPOSE)
 
-
+link-macos:
+		docker run -v /run/host-services/ssh-auth.sock:/run/host-services/ssh-auth.sock -e SSH_AUTH_SOCK="/run/host-services/ssh-auth.sock" --rm -it fractalnetworks/gateway-cli:latest $(GATEWAY) $(FQDN) $(EXPOSE)

--- a/gateway/scripts/_create-link.sh
+++ b/gateway/scripts/_create-link.sh
@@ -14,6 +14,5 @@ WIREGUARD_PORT=$(docker port $CONTAINER_NAME 18521/udp| head -n 1| sed "s/0\.0\.
 # get public ipv4 address
 GATEWAY_IP=$(curl -s 4.icanhazip.com)
 
-echo "export GATEWAY_LINK_WG_PUBKEY=$GATEWAY_LINK_WG_PUBKEY"
-echo "export GATEWAY_ENDPOINT=$GATEWAY_IP:$WIREGUARD_PORT"
+echo "$GATEWAY_LINK_WG_PUBKEY $GATEWAY_IP:$WIREGUARD_PORT"
 

--- a/gateway/scripts/_create-link.sh
+++ b/gateway/scripts/_create-link.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-set -x
+
+set -e
 
 CONTAINER_NAME=$1
 LINK_CLIENT_WG_PUBKEY=$2

--- a/gateway/scripts/create-link.sh
+++ b/gateway/scripts/create-link.sh
@@ -18,6 +18,7 @@ export CONTAINER_NAME=$(echo $LINK_DOMAIN|python3 -c 'fqdn=input();print("-".joi
 LINK_CLIENT_WG_PUBKEY=$(echo $WG_PRIVKEY|wg pubkey)
 LINK_ENV=$(ssh $SSH_HOST "bash -s" -- < ./_create-link.sh $CONTAINER_NAME $LINK_CLIENT_WG_PUBKEY)
 
+
 source <(echo $LINK_ENV)
 
 cat link-compose-snippet.yml | envsubst

--- a/gateway/scripts/create-link.sh
+++ b/gateway/scripts/create-link.sh
@@ -7,7 +7,7 @@ SSH_HOST=$1
 export LINK_DOMAIN=$2
 export EXPOSE=$3
 export WG_PRIVKEY=$(wg genkey)
-# Nginx uses Docker DNS resolver for dynamic mapping of LINK_DOMAIN to link containers hostnames, see nginx/*.conf
+# Nginx uses Docker DNS resolver for dynamic mapping of LINK_DOMAIN to link container hostnames, see nginx/*.conf
 # This is the magic.
 # NOTE: All traffic for `*.subdomain.domain.tld`` will be routed to the container named `subdomain-domain-tld``
 # Also supports `subdomain.domain.tld` as well as apex `domain.tld`
@@ -18,8 +18,11 @@ export CONTAINER_NAME=$(echo $LINK_DOMAIN|python3 -c 'fqdn=input();print("-".joi
 LINK_CLIENT_WG_PUBKEY=$(echo $WG_PRIVKEY|wg pubkey)
 LINK_ENV=$(ssh $SSH_HOST "bash -s" -- < ./_create-link.sh $CONTAINER_NAME $LINK_CLIENT_WG_PUBKEY)
 
+# convert to array
+RESULT=($LINK_ENV)
 
-source <(echo $LINK_ENV)
+export GATEWAY_LINK_WG_PUBKEY=${RESULT[0]}
+export GATEWAY_ENDPOINT=${RESULT[1]}
 
 cat link-compose-snippet.yml | envsubst
 


### PR DESCRIPTION
- add macos specific make target for passing in docker for desktop ssh-agent sock
- `source <(echo $LINK_ENV)` was problematic on macOS, return a string instead, split string and access array values instead