### PR TITLE
Configurable MTU defaultling to 1380

### DIFF
--- a/gateway/Dockerfile.gateway-link
+++ b/gateway/Dockerfile.gateway-link
@@ -7,5 +7,6 @@ ADD link-entrypoint.sh /usr/bin/link-entrypoint.sh
 RUN apk add iptables socat wireguard-tools
 
 ENV NOTEWORTHY_ENV $RELEASE_TAG
+ENV LINK_MTU=1380
 
 ENTRYPOINT [ "link-entrypoint.sh" ]

--- a/gateway/link-entrypoint.sh
+++ b/gateway/link-entrypoint.sh
@@ -10,6 +10,7 @@ wg set link0 private-key /etc/wireguard/link0.key
 wg set link0 listen-port 18521
 ip addr add 10.0.0.1/24 dev link0
 ip link set link0 up
+ip link set link0 mtu $LINK_MTU
 
 wg set link0 peer $LINK_CLIENT_WG_PUBKEY allowed-ips 10.0.0.2/32
 


### PR DESCRIPTION
Some people are less fortunate with their ISPs in that they need to use a non-default MTU. In order to make it as simple as possible, this change sets the default MTU to 1380 which should be a fairly safe bet for most installations. The MTU can be overridden using the `LINK_MTU` env variable for the Docker container.