### PR TITLE
Add support for App-Subdomain-Domain-TLD

### DIFF
--- a/src/create-link/entrypoint.sh
+++ b/src/create-link/entrypoint.sh
@@ -12,7 +12,7 @@ export WG_PRIVKEY=$(wg genkey)
 # NOTE: All traffic for `*.subdomain.domain.tld`` will be routed to the container named `subdomain-domain-tld``
 # Also supports `subdomain.domain.tld` as well as apex `domain.tld`
 # *.domain.tld should resolve to the Gateway's public IPv4 address
-export CONTAINER_NAME=$(echo $LINK_DOMAIN|python3 -c 'fqdn=input();print("-".join(fqdn.split(".")[-3:]))')
+export CONTAINER_NAME=$(echo $LINK_DOMAIN|python3 -c 'fqdn=input();print("-".join(fqdn.split(".")))')
 
 
 LINK_CLIENT_WG_PUBKEY=$(echo $WG_PRIVKEY|wg pubkey)

--- a/src/create-link/entrypoint.sh
+++ b/src/create-link/entrypoint.sh
@@ -12,7 +12,7 @@ export WG_PRIVKEY=$(wg genkey)
 # NOTE: All traffic for `*.subdomain.domain.tld`` will be routed to the container named `subdomain-domain-tld``
 # Also supports `subdomain.domain.tld` as well as apex `domain.tld`
 # *.domain.tld should resolve to the Gateway's public IPv4 address
-export CONTAINER_NAME=$(echo $LINK_DOMAIN|python3 -c 'fqdn=input();print("-".join(fqdn.split(".")))')
+export CONTAINER_NAME=$(echo $LINK_DOMAIN|python3 -c 'fqdn=input();print("-".join(fqdn.split(".")[-4:]))')
 
 
 LINK_CLIENT_WG_PUBKEY=$(echo $WG_PRIVKEY|wg pubkey)

--- a/src/gateway/nginx.conf.template
+++ b/src/gateway/nginx.conf.template
@@ -31,7 +31,7 @@ events {
 
     stream {  
         map $ssl_preread_server_name $targetBackend {
-            ~^(?<app>.+?)?\.(?<subdomain>.+?)?\.(?<domain>.+)\.(?<tld>.+)$ $subdomain-$domain-$tld:443;
+            ~^(?<app>.+?)?\.(?<subdomain>.+?)?\.(?<domain>.+)\.(?<tld>.+)$ $app-$subdomain-$domain-$tld:443;
             ~^(?<subdomain>.+?)?\.(?<domain>.+)\.(?<tld>.+)$ $subdomain-$domain-$tld:443;
             ~^(?<domain>.+)\.(?<tld>.+)$ $domain-$tld:443;
         } 


### PR DESCRIPTION
Previously, if a domain used the format app.subdomain.domain.tld, entrypoint.sh would fail to rename the docker images correctly.
A domain like this: 
app.subdomain.domain.tld  
will be named
subdomain-domain-tld

creating a duplicate container name error if attempting to host multiple services using that gateway. 

This adds a higher string slice [-3:] -> [-4:] which now correctly names app level domains as app-subdomain-domain-tld.
It also adds the app name to the nginx.conf.template, which will correctly parse app-subdomain-domain-tld.

I ran into this issue with a duckdns domain, which looks like the following: app.mydomain.duckdns.org, making all my containers named mydomain-duckdns-org, causing duplicate container issues. 