### PR TITLE
Add static port support and insecure backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ gateway: docker
 	docker run --network gateway --restart unless-stopped -p 80:80 -p 443:443 -e NGINX_ENVSUBST_OUTPUT_DIR=/etc/nginx -it -d fractalnetworks/selfhosted-gateway:latest
 
 link:
-	docker run -e SSH_AGENT_PID=$$SSH_AGENT_PID -e SSH_AUTH_SOCK=$$SSH_AUTH_SOCK -v $$SSH_AUTH_SOCK:$$SSH_AUTH_SOCK --rm -it fractalnetworks/gateway-cli:latest $(GATEWAY) $(FQDN) $(EXPOSE)
+	docker run -e SSH_AGENT_PID=$$SSH_AGENT_PID -e SSH_AUTH_SOCK=$$SSH_AUTH_SOCK -v $$SSH_AUTH_SOCK:$$SSH_AUTH_SOCK --rm -it fractalnetworks/gateway-cli:latest $(GATEWAY) $(FQDN) $(EXPOSE) $(INSECURE)
 
 link-macos:
-	docker run -v /run/host-services/ssh-auth.sock:/run/host-services/ssh-auth.sock -e SSH_AUTH_SOCK="/run/host-services/ssh-auth.sock" --rm -it fractalnetworks/gateway-cli:latest $(GATEWAY) $(FQDN) $(EXPOSE)
+	docker run -v /run/host-services/ssh-auth.sock:/run/host-services/ssh-auth.sock -e SSH_AUTH_SOCK="/run/host-services/ssh-auth.sock" --rm -it fractalnetworks/gateway-cli:latest $(GATEWAY) $(FQDN) $(EXPOSE) $(INSECURE)

--- a/src/client-link/entrypoint.sh
+++ b/src/client-link/entrypoint.sh
@@ -17,6 +17,31 @@ wg set link0 peer $GATEWAY_LINK_WG_PUBKEY allowed-ips 10.0.0.1/32 persistent-kee
 if [ -z ${FORWARD_ONLY+x} ]
 then
     echo "Using caddy with SSL termination to forward traffic to app."
+    if [ "${INSECURE+set}" = set ];
+    then
+        export EXPOSE=$(cat <<-END
+$EXPOSE {
+         transport http {
+            tls
+            tls_insecure_skip_verify
+            read_buffer 8192
+         }
+       }
+END
+)
+
+    else
+        export EXPOSE=$(cat <<-END
+$EXPOSE {
+         transport http {
+            tls
+            read_buffer 8192
+         }
+       }
+END
+)
+    fi
+
     envsubst < /etc/Caddyfile.template > /etc/Caddyfile
     caddy run --config /etc/Caddyfile
 else

--- a/src/create-link/entrypoint.sh
+++ b/src/create-link/entrypoint.sh
@@ -6,6 +6,7 @@ set -e
 SSH_HOST=$1
 export LINK_DOMAIN=$2
 export EXPOSE=$3
+export INSECURE=$4
 export WG_PRIVKEY=$(wg genkey)
 # Nginx uses Docker DNS resolver for dynamic mapping of LINK_DOMAIN to link container hostnames, see nginx/*.conf
 # This is the magic.
@@ -23,6 +24,18 @@ RESULT=($LINK_ENV)
 
 export GATEWAY_LINK_WG_PUBKEY=${RESULT[0]}
 export GATEWAY_ENDPOINT=${RESULT[1]}
+
+if [ ! -z "$INSECURE" ];
+then
+    if [ $(echo $INSECURE | tr '[:upper:]' '[:lower:]') = "true" ];
+    then
+export EXPOSE=$(cat <<-END
+$EXPOSE
+      INSECURE: "true"
+END
+)
+    fi
+fi
 
 cat link-compose-snippet.yml | envsubst
 

--- a/src/create-link/remote.sh
+++ b/src/create-link/remote.sh
@@ -7,10 +7,18 @@ LINK_CLIENT_WG_PUBKEY=$2
 
 # create gateway-link container
 CONTAINER_ID=$(docker run --name $CONTAINER_NAME --network gateway -p 18521/udp --cap-add NET_ADMIN --restart unless-stopped -it -e LINK_CLIENT_WG_PUBKEY=$LINK_CLIENT_WG_PUBKEY -d fractalnetworks/gateway-link:latest)
+# get randomly assigned WireGuard port
+WIREGUARD_PORT=$(docker port $CONTAINER_NAME 18521/udp| head -n 1| sed "s/0\.0\.0\.0://")
+
+docker stop $CONTAINER_ID 2>& 1>NUL
+docker rm $CONTAINER_ID 2>& 1>NUL
+
+# create gateway-link container
+CONTAINER_ID=$(docker run --name $CONTAINER_NAME --network gateway -p $WIREGUARD_PORT:18521/udp --cap-add NET_ADMIN --restart unless-stopped -it -e LINK_CLIENT_WG_PUBKEY=$LINK_CLIENT_WG_PUBKEY -d fractalnetworks/gateway-link:latest)
 # get gateway-link WireGuard pubkey 
 GATEWAY_LINK_WG_PUBKEY=$(docker exec $CONTAINER_NAME bash -c 'cat /etc/wireguard/link0.key |wg pubkey')
 # get randomly assigned WireGuard port
-WIREGUARD_PORT=$(docker port $CONTAINER_NAME 18521/udp| head -n 1| sed "s/0\.0\.0\.0://")
+#WIREGUARD_PORT=$(docker port $CONTAINER_NAME 18521/udp| head -n 1| sed "s/0\.0\.0\.0://")
 # get public ipv4 address
 GATEWAY_IP=$(curl -s 4.icanhazip.com)
 


### PR DESCRIPTION
Previously, when the gateway server was restarted, a random port was selected. This meant that the port always had to be adjusted on the client, which led to problems with multiple instances.

The container is now started with a random port to determine the port. The container is then deleted and started with the fixed port.


In addition, the InSecure option has been added, as the connection in Caddy does not work with self-signed certificates.