### PR TITLE
Fix Startup Problem from PR #31

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ gateway: docker
 	docker run --network gateway --restart unless-stopped -p 80:80 -p 443:443 -e NGINX_ENVSUBST_OUTPUT_DIR=/etc/nginx -it -d fractalnetworks/selfhosted-gateway:latest
 
 link:
-	docker run -e SSH_AGENT_PID=$$SSH_AGENT_PID -e SSH_AUTH_SOCK=$$SSH_AUTH_SOCK -v $$SSH_AUTH_SOCK:$$SSH_AUTH_SOCK --rm -it fractalnetworks/gateway-cli:latest $(GATEWAY) $(FQDN) $(EXPOSE) $(IN_SECURE_TLS)
+	docker run -e SSH_AGENT_PID=$$SSH_AGENT_PID -e SSH_AUTH_SOCK=$$SSH_AUTH_SOCK -v $$SSH_AUTH_SOCK:$$SSH_AUTH_SOCK --rm -it fractalnetworks/gateway-cli:latest $(GATEWAY) $(FQDN) $(EXPOSE)
 
 link-macos:
-	docker run -v /run/host-services/ssh-auth.sock:/run/host-services/ssh-auth.sock -e SSH_AUTH_SOCK="/run/host-services/ssh-auth.sock" --rm -it fractalnetworks/gateway-cli:latest $(GATEWAY) $(FQDN) $(EXPOSE) $(IN_SECURE_TLS)
+	docker run -v /run/host-services/ssh-auth.sock:/run/host-services/ssh-auth.sock -e SSH_AUTH_SOCK="/run/host-services/ssh-auth.sock" --rm -it fractalnetworks/gateway-cli:latest $(GATEWAY) $(FQDN) $(EXPOSE}

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ gateway: docker
 	docker run --network gateway --restart unless-stopped -p 80:80 -p 443:443 -e NGINX_ENVSUBST_OUTPUT_DIR=/etc/nginx -it -d fractalnetworks/selfhosted-gateway:latest
 
 link:
-	docker run -e SSH_AGENT_PID=$$SSH_AGENT_PID -e SSH_AUTH_SOCK=$$SSH_AUTH_SOCK -v $$SSH_AUTH_SOCK:$$SSH_AUTH_SOCK --rm -it fractalnetworks/gateway-cli:latest $(GATEWAY) $(FQDN) $(EXPOSE) $(INSECURE)
+	docker run -e SSH_AGENT_PID=$$SSH_AGENT_PID -e SSH_AUTH_SOCK=$$SSH_AUTH_SOCK -v $$SSH_AUTH_SOCK:$$SSH_AUTH_SOCK --rm -it fractalnetworks/gateway-cli:latest $(GATEWAY) $(FQDN) $(EXPOSE) $(IN_SECURE_TLS)
 
 link-macos:
-	docker run -v /run/host-services/ssh-auth.sock:/run/host-services/ssh-auth.sock -e SSH_AUTH_SOCK="/run/host-services/ssh-auth.sock" --rm -it fractalnetworks/gateway-cli:latest $(GATEWAY) $(FQDN) $(EXPOSE) $(INSECURE)
+	docker run -v /run/host-services/ssh-auth.sock:/run/host-services/ssh-auth.sock -e SSH_AUTH_SOCK="/run/host-services/ssh-auth.sock" --rm -it fractalnetworks/gateway-cli:latest $(GATEWAY) $(FQDN) $(EXPOSE) $(IN_SECURE_TLS)

--- a/README.md
+++ b/README.md
@@ -135,6 +135,33 @@ traefikv2_link.1.qvijxtwiu0wb@docker01    | + socat TCP4-LISTEN:8443,fork,reusea
 traefikv2_link.1.qvijxtwiu0wb@docker01    | + socat TCP4-LISTEN:8080,fork,reuseaddr TCP4:app:80,reuseaddr
 ```
 
+### TLS Backend
+
+If the backend container already has a TLS certification, the connection between Caddy and the backend container can be switched to TLS/HTTPS with the `CADDY_TLS_PROXY` parameter.
+In case the certificate is self-signed, the addition `CADDY_TLS_INSECURE` can be used to deactivate the certificate check.
+
+This will continue to create a certificate for the backend via Let's Encrypt.
+
+```yaml
+version: '3.9'
+services:
+  app:
+    image: traefik:latest
+  link:
+    image: fractalnetworks/gateway-client:latest
+    environment:
+      LINK_DOMAIN: sub.mydomain.com
+      EXPOSE:  https://app:80
+      CADDY_TLS_PROXY: true
+      # Optional
+      # CADDY_TLS_INSECURE: true
+      GATEWAY_CLIENT_WG_PRIVKEY: 4M7Ap0euzTxq7gTA/WIYIt3nU+i2FvHUc9eYTFQ2CGI=
+      GATEWAY_LINK_WG_PUBKEY: Wipd6Pv7ttmII4/Oj82I5tmGZwuw6ucsE3G+hwsMR08=
+      GATEWAY_ENDPOINT: 5.161.127.102:49185
+    cap_add:
+      - NET_ADMIN
+```
+
 ### Show all links running on a Gateway
 ```
 $ docker ps

--- a/src/client-link/entrypoint.sh
+++ b/src/client-link/entrypoint.sh
@@ -14,12 +14,14 @@ ip link set link0 mtu $LINK_MTU
 
 wg set link0 peer $GATEWAY_LINK_WG_PUBKEY allowed-ips 10.0.0.1/32 persistent-keepalive 30 endpoint $GATEWAY_ENDPOINT
 
-if [ -z ${FORWARD_ONLY+x} ]
-then
+if [ -z ${FORWARD_ONLY+x} ]; then
+
     echo "Using caddy with SSL termination to forward traffic to app."
-    if [ "${INSECURE+set}" = set ];
-    then
-        export EXPOSE=$(cat <<-END
+    if [ ! -z ${IN_SECURE_TLS+x} ]; then
+        echo "Configure Caddy for use with TLS backend (Insecure $IN_SECURE_TLS)"
+        if [ "$IN_SECURE_TLS" = true ]; then
+
+            export EXPOSE=$(cat <<-END
 $EXPOSE {
          transport http {
             tls
@@ -30,8 +32,8 @@ $EXPOSE {
 END
 )
 
-    else
-        export EXPOSE=$(cat <<-END
+        else
+            export EXPOSE=$(cat <<-END
 $EXPOSE {
          transport http {
             tls
@@ -40,8 +42,8 @@ $EXPOSE {
        }
 END
 )
+        fi
     fi
-
     envsubst < /etc/Caddyfile.template > /etc/Caddyfile
     caddy run --config /etc/Caddyfile
 else

--- a/src/client-link/entrypoint.sh
+++ b/src/client-link/entrypoint.sh
@@ -17,10 +17,10 @@ wg set link0 peer $GATEWAY_LINK_WG_PUBKEY allowed-ips 10.0.0.1/32 persistent-kee
 if [ -z ${FORWARD_ONLY+x} ]; then
 
     echo "Using caddy with SSL termination to forward traffic to app."
-    if [ ! -z ${IN_SECURE_TLS+x} ]; then
-        echo "Configure Caddy for use with TLS backend (Insecure $IN_SECURE_TLS)"
-        if [ "$IN_SECURE_TLS" = true ]; then
-
+    if [ ! -z ${CADDY_TLS_PROXY+x} ]; then
+        echo "Configure Caddy for use with TLS backend"
+        if [ ! -z ${CADDY_TLS_INSECURE+x} ]; then
+            echo "Skip TLS verification"
             export EXPOSE=$(cat <<-END
 $EXPOSE {
          transport http {

--- a/src/create-link/entrypoint.sh
+++ b/src/create-link/entrypoint.sh
@@ -6,7 +6,9 @@ set -e
 SSH_HOST=$1
 export LINK_DOMAIN=$2
 export EXPOSE=$3
-export INSECURE=$4
+
+if [ ! -z ${4+x} ]; then export IN_SECURE_TLS=$4; fi
+
 export WG_PRIVKEY=$(wg genkey)
 # Nginx uses Docker DNS resolver for dynamic mapping of LINK_DOMAIN to link container hostnames, see nginx/*.conf
 # This is the magic.
@@ -25,13 +27,18 @@ RESULT=($LINK_ENV)
 export GATEWAY_LINK_WG_PUBKEY=${RESULT[0]}
 export GATEWAY_ENDPOINT=${RESULT[1]}
 
-if [ ! -z "$INSECURE" ];
-then
-    if [ $(echo $INSECURE | tr '[:upper:]' '[:lower:]') = "true" ];
-    then
-export EXPOSE=$(cat <<-END
+if [ ! -z ${IN_SECURE_TLS+x} ]; then
+
+    if [ $(echo $IN_SECURE_TLS | tr '[:upper:]' '[:lower:]') = "true" ]; then
+        export EXPOSE=$(cat <<-END
 $EXPOSE
-      INSECURE: "true"
+      IN_SECURE_TLS: true
+END
+)
+    else
+        export EXPOSE=$(cat <<-END
+$EXPOSE
+      IN_SECURE_TLS: false
 END
 )
     fi

--- a/src/create-link/entrypoint.sh
+++ b/src/create-link/entrypoint.sh
@@ -6,9 +6,6 @@ set -e
 SSH_HOST=$1
 export LINK_DOMAIN=$2
 export EXPOSE=$3
-
-if [ ! -z ${4+x} ]; then export IN_SECURE_TLS=$4; fi
-
 export WG_PRIVKEY=$(wg genkey)
 # Nginx uses Docker DNS resolver for dynamic mapping of LINK_DOMAIN to link container hostnames, see nginx/*.conf
 # This is the magic.
@@ -26,23 +23,6 @@ RESULT=($LINK_ENV)
 
 export GATEWAY_LINK_WG_PUBKEY=${RESULT[0]}
 export GATEWAY_ENDPOINT=${RESULT[1]}
-
-if [ ! -z ${IN_SECURE_TLS+x} ]; then
-
-    if [ $(echo $IN_SECURE_TLS | tr '[:upper:]' '[:lower:]') = "true" ]; then
-        export EXPOSE=$(cat <<-END
-$EXPOSE
-      IN_SECURE_TLS: true
-END
-)
-    else
-        export EXPOSE=$(cat <<-END
-$EXPOSE
-      IN_SECURE_TLS: false
-END
-)
-    fi
-fi
 
 cat link-compose-snippet.yml | envsubst
 


### PR DESCRIPTION
Fixes #31

Change the Parameter from INSECURE to IN_SECURE_TLS. If the parameter is set when creating or starting, a boolean true/false is checked and enables only TLS or TLS_INSECURE_SKIP_VERIFY. IF the parameter is not set, nothing changes in the function for my pull (I hope).

I have tried several links and hopefully I was able to solve the problem.

Unfortunately I am not completely happy with the implementation.
I have tried to adapt more to the actual coding style.

**Therefore the following question, would it be more user-friendly if there were two parameters?**

Once the parameter TLS to generally tell Caddy that the backend has a TLS connection?
And if needed, the parameter IN_SECURE_TLS to skip the verification of the backend ssl certificate?

Otherwise I would extend the readme.

And once again sorry for the issue and my learning is to split the functions.
