### PR TITLE
Handle Gateway in a private subnet

### DIFF
--- a/src/create-link/entrypoint.sh
+++ b/src/create-link/entrypoint.sh
@@ -35,21 +35,22 @@ export WG_PRIVKEY
 # This is the magic.
 # NOTE: All traffic for `*.subdomain.domain.tld`` will be routed to the container named `subdomain-domain-tld``
 # Also supports `subdomain.domain.tld` as well as apex `domain.tld`
-# *.domain.tld should resolve to the Gateway's public IPv4 address
+# *.domain.tld should resolve to the Gateway's access IPv4 address
 CONTAINER_NAME=$(fqdn_to_container_name "$LINK_DOMAIN")
 export CONTAINER_NAME
 
+# get gateway access ipv4 address
+GATEWAY_IP=$(getent ahostsv4 "$LINK_DOMAIN" | awk -v host="$LINK_DOMAIN" '$NF ~ host {print $1; exit}')
 
 LINK_CLIENT_WG_PUBKEY=$(echo $WG_PRIVKEY|wg pubkey)
 # LINK_ENV=$(ssh -o StrictHostKeyChecking=accept-new $SSH_HOST -p $SSH_PORT "bash -s" -- < ./remote.sh $CONTAINER_NAME $LINK_CLIENT_WG_PUBKEY > /dev/null 2>&1)
 LINK_ENV=$(ssh -o StrictHostKeyChecking=accept-new -o LogLevel=ERROR $SSH_HOST -p $SSH_PORT "bash -s" -- < ./remote.sh $CONTAINER_NAME $LINK_CLIENT_WG_PUBKEY)
 
-
 # convert to array
 RESULT=($LINK_ENV)
 
-export GATEWAY_LINK_WG_PUBKEY=${RESULT[0]}
-export GATEWAY_ENDPOINT=${RESULT[1]}
+export GATEWAY_LINK_WG_PUBKEY="${RESULT[0]}"
+export GATEWAY_ENDPOINT="${GATEWAY_IP}:${RESULT[1]}"
 
 cat link-compose-snippet.yml | envsubst
 

--- a/src/create-link/remote.sh
+++ b/src/create-link/remote.sh
@@ -19,8 +19,6 @@ CONTAINER_ID=$(docker run --name $CONTAINER_NAME --network gateway -p $WIREGUARD
 GATEWAY_LINK_WG_PUBKEY=$(docker exec $CONTAINER_NAME bash -c 'cat /etc/wireguard/link0.key |wg pubkey')
 # get randomly assigned WireGuard port
 #WIREGUARD_PORT=$(docker port $CONTAINER_NAME 18521/udp| head -n 1| sed "s/0\.0\.0\.0://")
-# get public ipv4 address
-GATEWAY_IP=$(curl -s 4.icanhazip.com)
 
-echo "$GATEWAY_LINK_WG_PUBKEY $GATEWAY_IP:$WIREGUARD_PORT"
+echo "$GATEWAY_LINK_WG_PUBKEY $WIREGUARD_PORT"
 


### PR DESCRIPTION
The FQDN to access the exposed service (`$LINK_DOMAIN`) should resolve to the IP address of the Gateway.
However, when the FQDN resolves to an IP in a private subnet, the `GATEWAY_ENDPOINT` (`$GATEWAY_IP:$WIREGUARD_PORT`) is not set correctly.
Use a DNS lookup to find the ~public~ access IP address of the Gateway, instead of looking for the public IP of the Gateway.