### PR TITLE
Add X-Forwarded-Proto header in reverse_proxy

### DIFF
--- a/src/client-link/Caddyfile.template
+++ b/src/client-link/Caddyfile.template
@@ -20,8 +20,6 @@ $LINK_DOMAIN {
     # optional internal tls
     $TLS_INTERNAL_CONFIG
 
-    reverse_proxy $EXPOSE {
-        header_up X-Forwarded-Proto {scheme}
-    }
+    reverse_proxy $EXPOSE
 
 }

--- a/src/client-link/Caddyfile.template
+++ b/src/client-link/Caddyfile.template
@@ -20,6 +20,8 @@ $LINK_DOMAIN {
     # optional internal tls
     $TLS_INTERNAL_CONFIG
 
-    reverse_proxy $EXPOSE
+    reverse_proxy $EXPOSE {
+        header_up X-Forwarded-Proto {scheme}
+    }
 
 }

--- a/src/client-link/entrypoint.sh
+++ b/src/client-link/entrypoint.sh
@@ -13,12 +13,7 @@ ip link set link0 up
 ip link set link0 mtu $LINK_MTU
 
 wg set link0 peer $GATEWAY_LINK_WG_PUBKEY allowed-ips 10.0.0.1/32 persistent-keepalive 30 endpoint $GATEWAY_ENDPOINT
-EXPOSE=$(cat <<-END
-$EXPOSE {
-         header_up X-Forwarded-Proto {scheme}
-       }
-END
-)
+
 if [ -z ${FORWARD_ONLY+x} ]; then
 
     echo "Using caddy with SSL termination to forward traffic to app."
@@ -33,6 +28,7 @@ $EXPOSE {
             tls_insecure_skip_verify
             read_buffer 8192
          }
+         header_up X-Forwarded-Proto {scheme}
        }
 END
 )
@@ -44,10 +40,18 @@ $EXPOSE {
             tls
             read_buffer 8192
          }
+         header_up X-Forwarded-Proto {scheme}
        }
 END
 )
         fi
+        else
+         EXPOSE=$(cat <<-END
+$EXPOSE {
+         header_up X-Forwarded-Proto {scheme}
+       }
+END
+)
     fi
 
     CADDYFILE='/etc/Caddyfile'

--- a/src/client-link/entrypoint.sh
+++ b/src/client-link/entrypoint.sh
@@ -13,7 +13,12 @@ ip link set link0 up
 ip link set link0 mtu $LINK_MTU
 
 wg set link0 peer $GATEWAY_LINK_WG_PUBKEY allowed-ips 10.0.0.1/32 persistent-keepalive 30 endpoint $GATEWAY_ENDPOINT
-
+export EXPOSE=$(cat <<-END
+$EXPOSE {
+        header_up X-Forwarded-Proto {scheme}
+    }
+END
+)
 if [ -z ${FORWARD_ONLY+x} ]; then
 
     echo "Using caddy with SSL termination to forward traffic to app."

--- a/src/client-link/entrypoint.sh
+++ b/src/client-link/entrypoint.sh
@@ -13,10 +13,10 @@ ip link set link0 up
 ip link set link0 mtu $LINK_MTU
 
 wg set link0 peer $GATEWAY_LINK_WG_PUBKEY allowed-ips 10.0.0.1/32 persistent-keepalive 30 endpoint $GATEWAY_ENDPOINT
-export EXPOSE=$(cat <<-END
+EXPOSE=$(cat <<-END
 $EXPOSE {
-        header_up X-Forwarded-Proto {scheme}
-    }
+         header_up X-Forwarded-Proto {scheme}
+       }
 END
 )
 if [ -z ${FORWARD_ONLY+x} ]; then
@@ -26,7 +26,7 @@ if [ -z ${FORWARD_ONLY+x} ]; then
         echo "Configure Caddy for use with TLS backend"
         if [ ! -z ${CADDY_TLS_INSECURE+x} ]; then   # if CADDY_TLS_INSECURE
             echo "Skip TLS verification"
-            export EXPOSE=$(cat <<-END
+            EXPOSE=$(cat <<-END
 $EXPOSE {
          transport http {
             tls
@@ -38,7 +38,7 @@ END
 )
 
         else    # CADDY_TLS_INSECURE is false
-            export EXPOSE=$(cat <<-END
+            EXPOSE=$(cat <<-END
 $EXPOSE {
          transport http {
             tls
@@ -77,6 +77,7 @@ END
 END
     )
     fi
+    export EXPOSE
     export TLS_INTERNAL_CONFIG
     envsubst < /etc/Caddyfile.template > $CADDYFILE
     caddy run --config $CADDYFILE


### PR DESCRIPTION
Closes #55 

Correctly forward the protocol to the exposed container. Useful when using a link to expose an nginx or some other proxy. 