### PR TITLE
Adds ability to use a specific gateway network

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 .PHONY: docker link setup gateway ci
 
+GATEWAY_NETWORK=gateway
+
 docker:
 	docker build -t fractalnetworks/selfhosted-gateway:latest ./src/gateway/
 	docker build -t fractalnetworks/gateway-link:latest ./src/gateway-link/
@@ -7,16 +9,16 @@ docker:
 	docker build -t fractalnetworks/gateway-cli:latest ./src/create-link/
 
 setup:
-	docker network create gateway
+	docker network create $(GATEWAY_NETWORK)
 
 gateway: docker
-	docker run --network gateway --restart unless-stopped -p 80:80 -p 443:443 -e NGINX_ENVSUBST_OUTPUT_DIR=/etc/nginx -it -d fractalnetworks/selfhosted-gateway:latest
+	docker run --network $(GATEWAY_NETWORK) --restart unless-stopped -p 80:80 -p 443:443 -e NGINX_ENVSUBST_OUTPUT_DIR=/etc/nginx -it -d fractalnetworks/selfhosted-gateway:latest
 
 link:
-	docker run -e SSH_AGENT_PID=$$SSH_AGENT_PID -e SSH_AUTH_SOCK=$$SSH_AUTH_SOCK -v $$SSH_AUTH_SOCK:$$SSH_AUTH_SOCK -v "$$PWD:/workdir" --rm -it fractalnetworks/gateway-cli:latest $(GATEWAY) $(FQDN) $(EXPOSE)
+	docker run -e GATEWAY_NETWORK=$(GATEWAY_NETWORK) -e SSH_AGENT_PID=$$SSH_AGENT_PID -e SSH_AUTH_SOCK=$$SSH_AUTH_SOCK -v $$SSH_AUTH_SOCK:$$SSH_AUTH_SOCK -v "$$PWD:/workdir" --rm -it fractalnetworks/gateway-cli:latest $(GATEWAY) $(FQDN) $(EXPOSE)
 
 link-macos:
-	docker run -v /run/host-services/ssh-auth.sock:/run/host-services/ssh-auth.sock -e SSH_AUTH_SOCK="/run/host-services/ssh-auth.sock" -v "$$PWD:/workdir" --rm -it fractalnetworks/gateway-cli:latest $(GATEWAY) $(FQDN) $(EXPOSE)
+	docker run -v /run/host-services/ssh-auth.sock:/run/host-services/ssh-auth.sock -e GATEWAY_NETWORK=$(GATEWAY_NETWORK) -e SSH_AUTH_SOCK="/run/host-services/ssh-auth.sock" -v "$$PWD:/workdir" --rm -it fractalnetworks/gateway-cli:latest $(GATEWAY) $(FQDN) $(EXPOSE)
 
 link-ci:
 	./ci/create-link-ci.sh $(GATEWAY) $(FQDN) nginx:80

--- a/src/create-link/entrypoint.sh
+++ b/src/create-link/entrypoint.sh
@@ -20,6 +20,8 @@ function fqdn_to_container_name() {
 
 SSH_HOST=$1
 SSH_PORT=22
+GATEWAY_NETWORK=${GATEWAY_NETWORK:-gateway}
+
 # split port from SSH_HOST if SSH_HOST contains :
 if [[ $SSH_HOST == *":"* ]]; then
   IFS=':' read -ra ADDR <<< "$SSH_HOST"
@@ -44,7 +46,7 @@ GATEWAY_IP=$(getent ahostsv4 "$LINK_DOMAIN" | awk '{print $1; exit}')
 
 LINK_CLIENT_WG_PUBKEY=$(echo $WG_PRIVKEY|wg pubkey)
 # LINK_ENV=$(ssh -o StrictHostKeyChecking=accept-new $SSH_HOST -p $SSH_PORT "bash -s" -- < ./remote.sh $CONTAINER_NAME $LINK_CLIENT_WG_PUBKEY > /dev/null 2>&1)
-LINK_ENV=$(ssh -o StrictHostKeyChecking=accept-new -o LogLevel=ERROR $SSH_HOST -p $SSH_PORT "bash -s" -- < ./remote.sh $CONTAINER_NAME $LINK_CLIENT_WG_PUBKEY)
+LINK_ENV=$(ssh -o StrictHostKeyChecking=accept-new -o LogLevel=ERROR $SSH_HOST -p $SSH_PORT "bash -s" -- < ./remote.sh $CONTAINER_NAME $LINK_CLIENT_WG_PUBKEY $GATEWAY_NETWORK)
 
 # convert to array
 RESULT=($LINK_ENV)

--- a/src/create-link/remote.sh
+++ b/src/create-link/remote.sh
@@ -4,17 +4,18 @@ set -e
 
 CONTAINER_NAME=$1
 LINK_CLIENT_WG_PUBKEY=$2
+GATEWAY_NETWORK=$3
 
 # create gateway-link container
-CONTAINER_ID=$(docker run --name $CONTAINER_NAME --network gateway -p 18521/udp --cap-add NET_ADMIN --restart unless-stopped -it -e LINK_CLIENT_WG_PUBKEY=$LINK_CLIENT_WG_PUBKEY -d fractalnetworks/gateway-link:latest)
+CONTAINER_ID=$(docker run --name $CONTAINER_NAME --network $GATEWAY_NETWORK -p 18521/udp --cap-add NET_ADMIN --restart unless-stopped -it -e LINK_CLIENT_WG_PUBKEY=$LINK_CLIENT_WG_PUBKEY -d fractalnetworks/gateway-link:latest)
 # get randomly assigned WireGuard port
 WIREGUARD_PORT=$(docker port $CONTAINER_NAME 18521/udp| head -n 1| sed "s/0\.0\.0\.0://")
 
 docker rm -f $CONTAINER_ID 2>& 1>NUL
 
 # create gateway-link container
-CONTAINER_ID=$(docker run --name $CONTAINER_NAME --network gateway -p $WIREGUARD_PORT:18521/udp --cap-add NET_ADMIN --restart unless-stopped -it -e LINK_CLIENT_WG_PUBKEY=$LINK_CLIENT_WG_PUBKEY -d fractalnetworks/gateway-link:latest)
-# get gateway-link WireGuard pubkey 
+CONTAINER_ID=$(docker run --name $CONTAINER_NAME --network $GATEWAY_NETWORK -p $WIREGUARD_PORT:18521/udp --cap-add NET_ADMIN --restart unless-stopped -it -e LINK_CLIENT_WG_PUBKEY=$LINK_CLIENT_WG_PUBKEY -d fractalnetworks/gateway-link:latest)
+# get gateway-link WireGuard pubkey
 GATEWAY_LINK_WG_PUBKEY=$(docker exec $CONTAINER_NAME bash -c 'cat /etc/wireguard/link0.key |wg pubkey')
 # get randomly assigned WireGuard port
 #WIREGUARD_PORT=$(docker port $CONTAINER_NAME 18521/udp| head -n 1| sed "s/0\.0\.0\.0://")


### PR DESCRIPTION
Anywhere --network is used now supports being provided a GATEWAY_NETWORK variable. If not provided it uses what was already used. 

`make network GATEWAY_NETWORK=some-gateway-network`
`make gateway GATEWAY_NETWORK=some-gateway-network`
`make link GATEWAY=<gateway> FQDN=<FQDN> EXPOSE=<EXPOSE> GATEWAY_NETWORK=some-gateway-network`
`make link-macos GATEWAY=<gateway> FQDN=<FQDN> EXPOSE=<EXPOSE> GATEWAY_NETWORK=some-gateway-network`

No tests added at this point.